### PR TITLE
Add pedigree toggle option to SVG graph view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import GraphView from './GraphView';
 import UploadButton from './UploadButton';
 import { parseTree } from './utils/parseTree';
 import { generateHTML } from './utils/generateHTML';
+import { buildPedigreeTree } from './utils/buildPedigree';
 import './App.css';
 
 const LS_TEXT = 'fte:lastTreeText';
@@ -23,6 +24,7 @@ export default function App() {
   // Top bar state
   const [rememberUpload, setRememberUpload] = useState(true);
   const [exportFocused, setExportFocused] = useState(false);
+  const [showPedigree, setShowPedigree] = useState(false);
 
   // Editor / data state
   const [treeText, setTreeText] = useState('');
@@ -63,6 +65,11 @@ export default function App() {
   const [focusedNode, setFocusedNode] = useState(null);
   const isFocused = Boolean(focusedNode);
   const displayedTree = isFocused ? [focusedNode] : fullTree;
+  const pedigreeTree = useMemo(() => {
+    if (!showPedigree || !focusedNode) return null;
+    const pedigree = buildPedigreeTree(fullTree, focusedNode.id);
+    return pedigree && pedigree.length > 0 ? pedigree : null;
+  }, [showPedigree, focusedNode, fullTree]);
   const handleUnfocus = () => setFocusedNode(null);
 
   // Enable/disable export buttons
@@ -145,6 +152,7 @@ export default function App() {
   };
 
   // Choose which tree to export based on "Export focused view"
+  const graphTree = pedigreeTree || displayedTree;
   const exportTree = exportFocused ? displayedTree : fullTree;
 
   const handleDownloadHTML = () => {
@@ -280,7 +288,18 @@ export default function App() {
       {/* Graph */}
       <div className="pane">
         <h3>Graph View</h3>
-        <GraphView tree={displayedTree} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <label style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              checked={showPedigree}
+              onChange={(e) => setShowPedigree(e.target.checked)}
+              disabled={!focusedNode}
+            />
+            Show pedigree when focused
+          </label>
+        </div>
+        <GraphView tree={graphTree} />
       </div>
     </div>
   );

--- a/src/utils/buildPedigree.js
+++ b/src/utils/buildPedigree.js
@@ -1,0 +1,61 @@
+export function buildPedigreeTree(roots, targetId) {
+  if (!Array.isArray(roots) || roots.length === 0 || !targetId) return null;
+
+  const path = findPathToNode(roots, targetId);
+  if (!path || path.length === 0) return null;
+
+  const focusNode = path[path.length - 1];
+  const focusClone = cloneWithChildren(focusNode);
+
+  let child = focusClone;
+  for (let i = path.length - 2; i >= 0; i -= 1) {
+    const ancestor = path[i];
+    child = {
+      ...ancestor,
+      children: [child],
+    };
+  }
+
+  return [child];
+}
+
+function cloneWithChildren(node) {
+  if (!node) return null;
+  return {
+    ...node,
+    children: Array.isArray(node.children)
+      ? node.children.map((child) => cloneWithChildren(child)).filter(Boolean)
+      : [],
+  };
+}
+
+function findPathToNode(roots, targetId) {
+  const stack = [];
+
+  const visit = (node) => {
+    if (!node) return false;
+    stack.push(node);
+    if (node.id === targetId) {
+      return true;
+    }
+
+    for (const child of node.children || []) {
+      if (visit(child)) {
+        return true;
+      }
+    }
+
+    stack.pop();
+    return false;
+  };
+
+  for (const root of roots) {
+    if (visit(root)) {
+      return stack.slice();
+    }
+  }
+
+  return null;
+}
+
+export default buildPedigreeTree;


### PR DESCRIPTION
## Summary
- add a pedigree tree builder to reuse focused node ancestry in the SVG renderer
- add a Graph View toggle that shows the pedigree for the focused person when enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da7a4e3f84832689e90aa3206cda25