### PR TITLE
Honor pedigree exports and document feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Family Tree Editor
 
-A lightweight web app for editing a plain‑text family tree and viewing it as an interactive tree and SVG diagram. You can **focus** on a sub‑tree (🔍), **unfocus** to restore the full view, and **export** HTML / SVG / JSON (optionally just the focused view). You can filter the tree to find instances of a string.
+A lightweight web app for editing a plain‑text family tree and viewing it as an interactive tree and SVG diagram. You can **focus** on a sub‑tree (🔍), surface a **pedigree lineage** for the focused person, **unfocus** to restore the full view, and **export** HTML / SVG / JSON (optionally just the focused or pedigree view). You can filter the tree to find instances of a string.
 
 ---
 
@@ -47,6 +47,7 @@ We had a legacy version of the Clan Family Tree trapped in an obsolete AutoCAD c
 3. The **Tree View** (right pane) updates live and provides keyboard navigation.
 4. Click 🔍 to **focus** on any node. Click **Unfocus** in the Tree View toolbar to restore.
 5. Turn on **Export focused view** (top‑right) to export only the focused sub‑tree.
+6. While a focus is active, enable **Show pedigree when focused** (Graph View) to display and export just that lineage.
 
 ---
 
@@ -65,11 +66,11 @@ Accessibility: the tree uses `role="tree"` / `role="treeitem"`, roving `tabIndex
 ## Exports & downloads
 
 - **Save edited text** — downloads the current editor text as `.txt`
-- **Download HTML** — static interactive page (collapsible tree)
+- **Download HTML** — static interactive page (collapsible tree or pedigree)
 - **Download SVG** — the graph view as raw SVG
 - **Download JSON** — the current tree data
 
-> Tip: check **Export focused view** to export only the currently focused sub‑tree.
+> Tip: check **Export focused view** to export only the currently focused sub‑tree, and pair it with **Show pedigree when focused** to export the lineage instead of the entire branch.
 
 ---
 

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import UploadButton from './UploadButton';
 import { parseTree } from './utils/parseTree';
 import { generateHTML } from './utils/generateHTML';
 import { buildPedigreeTree } from './utils/buildPedigree';
+import { treeToText } from './utils/treeToText';
 import './App.css';
 
 const LS_TEXT = 'fte:lastTreeText';
@@ -70,12 +71,19 @@ export default function App() {
     const pedigree = buildPedigreeTree(fullTree, focusedNode.id);
     return pedigree && pedigree.length > 0 ? pedigree : null;
   }, [showPedigree, focusedNode, fullTree]);
+  const focusExportTree = useMemo(() => {
+    if (!focusedNode) return null;
+    if (showPedigree && Array.isArray(pedigreeTree) && pedigreeTree.length > 0) {
+      return pedigreeTree;
+    }
+    return [focusedNode];
+  }, [focusedNode, showPedigree, pedigreeTree]);
   const handleUnfocus = () => setFocusedNode(null);
 
   // Enable/disable export buttons
   const hasExport = exportFocused
-    ? Boolean(focusedNode)
-    : Array.isArray(displayedTree) && displayedTree.length > 0;
+    ? Array.isArray(focusExportTree) && focusExportTree.length > 0
+    : Array.isArray(fullTree) && fullTree.length > 0;
 
   // Editor text change
   const handleTextChange = (next) => setTreeText(next);
@@ -152,18 +160,23 @@ export default function App() {
   };
 
   // Choose which tree to export based on "Export focused view"
-  const graphTree = pedigreeTree || displayedTree;
-  const exportTree = exportFocused ? displayedTree : fullTree;
+  const graphTree = focusExportTree || displayedTree;
+  const exportTree = exportFocused ? focusExportTree : fullTree;
 
   const handleDownloadHTML = () => {
-    const html = generateHTML(exportTree);
+    const html = generateHTML(exportTree ?? []);
     downloadAs('html', html, 'text/html');
   };
   const handleDownloadJSON = () => {
-    downloadAs('json', JSON.stringify(exportTree, null, 2), 'application/json');
+    const data = exportTree ?? [];
+    downloadAs('json', JSON.stringify(data, null, 2), 'application/json');
   };
   const handleDownloadTXT = () => {
-    downloadAs('txt', treeText ?? '', 'text/plain');
+    const content =
+      exportFocused && Array.isArray(focusExportTree)
+        ? treeToText(focusExportTree)
+        : (treeText ?? '');
+    downloadAs('txt', content, 'text/plain');
   };
 
   const graphHostRef = useRef(null);

--- a/src/tests/buildPedigree.test.js
+++ b/src/tests/buildPedigree.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { buildPedigreeTree } from '../utils/buildPedigree';
+
+const tree = [
+  {
+    id: 'root',
+    name: 'Root',
+    children: [
+      {
+        id: 'branch-a',
+        name: 'Branch A',
+        children: [
+          { id: 'leaf-a1', name: 'Leaf A1', children: [] },
+          {
+            id: 'leaf-a2',
+            name: 'Leaf A2',
+            children: [{ id: 'great', name: 'Great Grandchild', children: [] }],
+          },
+        ],
+      },
+      {
+        id: 'branch-b',
+        name: 'Branch B',
+        children: [{ id: 'leaf-b1', name: 'Leaf B1', children: [] }],
+      },
+    ],
+  },
+];
+
+describe('buildPedigreeTree', () => {
+  it('returns a single lineage from the focused node up to the root', () => {
+    const pedigree = buildPedigreeTree(tree, 'leaf-a2');
+    expect(pedigree).toEqual([
+      {
+        id: 'root',
+        name: 'Root',
+        children: [
+          {
+            id: 'branch-a',
+            name: 'Branch A',
+            children: [
+              {
+                id: 'leaf-a2',
+                name: 'Leaf A2',
+                children: [{ id: 'great', name: 'Great Grandchild', children: [] }],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('returns null when the target cannot be found', () => {
+    expect(buildPedigreeTree(tree, 'missing')).toBeNull();
+  });
+});

--- a/src/tests/treeToText.test.js
+++ b/src/tests/treeToText.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { treeToText } from '../utils/treeToText';
+
+const sampleTree = [
+  {
+    id: 'a',
+    name: 'Parent',
+    children: [
+      { id: 'b', name: 'Child 1', children: [] },
+      {
+        id: 'c',
+        name: 'Child 2',
+        children: [{ id: 'd', name: 'Grandchild', children: [] }],
+      },
+    ],
+  },
+];
+
+describe('treeToText', () => {
+  it('converts a forest into indented text', () => {
+    expect(treeToText(sampleTree)).toBe(
+      ['Parent', '    Child 1', '    Child 2', '        Grandchild'].join('\n'),
+    );
+  });
+
+  it('normalizes empty or whitespace names to "(unnamed)"', () => {
+    const forest = [{ id: 'x', name: '', children: [{ id: 'y', name: '   ', children: [] }] }];
+    expect(treeToText(forest)).toBe(['(unnamed)', '    (unnamed)'].join('\n'));
+  });
+
+  it('returns an empty string for null or empty input', () => {
+    expect(treeToText(null)).toBe('');
+    expect(treeToText([])).toBe('');
+  });
+});

--- a/src/utils/treeToText.js
+++ b/src/utils/treeToText.js
@@ -1,0 +1,37 @@
+// src/utils/treeToText.js
+// Convert a tree (single root or array of roots) into the tab-indented
+// text format understood by the editor. Used when exporting a focused
+// sub-tree or pedigree as plain text.
+
+function ensureArray(tree) {
+  if (!tree) return [];
+  return Array.isArray(tree) ? tree : [tree];
+}
+
+function formatName(value) {
+  const name = value == null ? '' : String(value);
+  const trimmed = name.trim();
+  return trimmed.length > 0 ? trimmed : '(unnamed)';
+}
+
+function walk(nodes, lines, depth) {
+  const indent = depth > 0 ? '    '.repeat(depth) : '';
+
+  nodes.forEach((node) => {
+    if (!node) return;
+    const label = formatName(node.name);
+    lines.push(`${indent}${label}`);
+
+    if (Array.isArray(node.children) && node.children.length > 0) {
+      walk(node.children, lines, depth + 1);
+    }
+  });
+}
+
+export function treeToText(tree) {
+  const lines = [];
+  walk(ensureArray(tree), lines, 0);
+  return lines.join('\n');
+}
+
+export default treeToText;


### PR DESCRIPTION
## Summary
- ensure export downloads respect the focused and pedigree views, including HTML, JSON, and text
- add utilities and unit tests for formatting focused trees and verifying pedigree output
- document the pedigree option across the README

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68daba96780c8326a3c6ac67a5797a42