### PR TITLE
Feat/improve screen reader accessibility (#77)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,6 +46,19 @@ body {
   margin: 0 auto;
 }
 
+/* Screen reader only content */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .toolbar-right {
   display: flex;
   align-items: center;

--- a/src/App.js
+++ b/src/App.js
@@ -222,6 +222,9 @@ export default function App() {
 
   return (
     <div className="app">
+      {/* Screen reader announcements */}
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only" />
+
       {/* Top toolbar */}
       <div
         className="top-toolbar"
@@ -233,7 +236,33 @@ export default function App() {
           marginBottom: 12,
         }}
       >
+        {/* LEFT: file/open/save */}
         <div
+          role="group"
+          aria-label="File operations"
+          style={{ display: 'inline-flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}
+        >
+          <UploadButton onLoaded={handleFileLoaded} />
+
+          <label style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              checked={rememberUpload}
+              onChange={(e) => setRememberUpload(e.target.checked)}
+              aria-label="Remember last upload"
+            />
+            Remember last upload
+          </label>
+
+          <button className="btn" onClick={handleSaveEdited} aria-label="Save edited text">
+            Save edited text
+          </button>
+        </div>
+
+        {/* RIGHT: export + downloads */}
+        <div
+          role="group"
+          aria-label="Export operations"
           style={{
             marginLeft: 'auto',
             display: 'inline-flex',
@@ -247,20 +276,41 @@ export default function App() {
               type="checkbox"
               checked={exportFocused}
               onChange={(e) => setExportFocused(e.target.checked)}
+              aria-label="Export focused view"
             />
             Export focused view
           </label>
 
-          <button className="btn" onClick={handleDownloadHTML} disabled={!canExport}>
+          <button
+            className="btn"
+            onClick={handleDownloadHTML}
+            disabled={!canExport}
+            aria-label={canExport ? 'Download HTML' : 'Download HTML (no data available)'}
+          >
             Download HTML
           </button>
-          <button className="btn" onClick={handleDownloadJSON} disabled={!canExport}>
+          <button
+            className="btn"
+            onClick={handleDownloadJSON}
+            disabled={!canExport}
+            aria-label={canExport ? 'Download JSON' : 'Download JSON (no data available)'}
+          >
             Download JSON
           </button>
-          <button className="btn" onClick={handleDownloadTXT} disabled={!canExport}>
+          <button
+            className="btn"
+            onClick={handleDownloadTXT}
+            disabled={!canExport}
+            aria-label={canExport ? 'Download TXT' : 'Download TXT (no data available)'}
+          >
             Download TXT
           </button>
-          <button className="btn" onClick={handleDownloadSVG} disabled={!canExport}>
+          <button
+            className="btn"
+            onClick={handleDownloadSVG}
+            disabled={!canExport}
+            aria-label={canExport ? 'Download SVG' : 'Download SVG (no data available)'}
+          >
             Download SVG
           </button>
         </div>
@@ -291,10 +341,11 @@ export default function App() {
                     type="checkbox"
                     checked={rememberUpload}
                     onChange={(e) => setRememberUpload(e.target.checked)}
+                    aria-label="Remember last upload"
                   />
                   Remember last upload
                 </label>
-                <button className="btn" onClick={handleSaveEdited}>
+                <button className="btn" onClick={handleSaveEdited} aria-label="Save edited text">
                   Save edited text
                 </button>
               </div>
@@ -326,6 +377,7 @@ export default function App() {
                   checked={showPedigree}
                   onChange={(e) => setShowPedigree(e.target.checked)}
                   disabled={!focusedNode}
+                  aria-label="Show pedigree when focused"
                 />
                 Show pedigree when focused
               </label>

--- a/src/e2e/treeview-a11y.spec.js
+++ b/src/e2e/treeview-a11y.spec.js
@@ -13,6 +13,9 @@ test('TreeView moves focus with Arrow keys', async ({ page }) => {
     .or(page.locator('textarea'));
   await editor.fill(sample);
 
+  // Switch to Tree View tab
+  await page.getByRole('button', { name: 'Tree View' }).click();
+
   // Wait for at least one treeitem to appear
   const items = page.getByRole('treeitem');
   await expect(items.first()).toBeVisible();


### PR DESCRIPTION
* fix: scope release drafter to main

* fix: dedupe export tree selection

* fix: use preview environment for pages PRs

* chore: format README

* feat: improve screen reader accessibility

- Add ARIA labels to all checkboxes and buttons
- Add descriptive labels for disabled export buttons
- Add role="group" with labels for toolbar sections
- Add aria-live region for screen reader announcements
- Add .sr-only CSS class for visually hidden content

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* fix: resolve merge conflict and restore ARIA labels

* fix: update E2E test for tabbed layout

---------

## Summary

<!-- What does this change do? Why? -->

## Screenshots / Demos (if UI)

<!-- GIF or screenshot, especially for TreeView/Editor changes -->

## Checklist

- [ ] Tests added/updated (Vitest and/or Playwright if needed)
- [ ] A11y sanity (keyboard, focus ring, labels)
- [ ] Docs/README updated if behavior changes
- [ ] CI green (Lint & format, Unit (summary), E2E (summary))

## Linked issues

Fixes #
